### PR TITLE
Changes: Set swift compiler version to 4.2 and some fixes (renamings)

### DIFF
--- a/ChartLegends.xcodeproj/project.pbxproj
+++ b/ChartLegends.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 				TargetAttributes = {
 					6A8C15701E19707700936AC6 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = 37QAPDY2PR;
+						DevelopmentTeam = LHAA3QSYMW;
 						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 					};
@@ -557,13 +557,13 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 37QAPDY2PR;
+				DEVELOPMENT_TEAM = LHAA3QSYMW;
 				INFOPLIST_FILE = "$(SRCROOT)/ChartLegendsDemo/Supporting files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schuetz.ChartLegendsDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -572,13 +572,13 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 37QAPDY2PR;
+				DEVELOPMENT_TEAM = LHAA3QSYMW;
 				INFOPLIST_FILE = "$(SRCROOT)/ChartLegendsDemo/Supporting files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schuetz.ChartLegendsDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -599,7 +599,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -622,7 +622,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/ChartLegends/View/ChartLegendsView.swift
+++ b/ChartLegends/View/ChartLegendsView.swift
@@ -120,7 +120,7 @@ open class ChartLegendsView: UIView {
             
         case .flowLeft:
             let flowLayout = LeftAlignedCollectionViewFlowLayout()
-            flowLayout.scrollDirection = UICollectionViewScrollDirection.vertical
+            flowLayout.scrollDirection = UICollectionView.ScrollDirection.vertical
             sharedFlowLayoutSettings(flowLayout: flowLayout)
             return flowLayout
             


### PR DESCRIPTION
Hallo,
I want to use ChartLegends with a Swift 4.2 project, but ChartLegends had the compiler version 4.0. So I have change this in project settings and have also done a little fix in ChartLegendsView.swift (Renaming UICollectionViewScrollDirection to UICollectionView.ScrollDirection).

Best regards

S. Tanneberger